### PR TITLE
Spo2 requirement fix documentation

### DIFF
--- a/R/phoenix_respiratory.R
+++ b/R/phoenix_respiratory.R
@@ -11,7 +11,7 @@
 #' oximetry (SpO2) instead of invasive PaO2.
 #'
 #' Important Note: when the Phoenix Sepsis criteria was developed there is
-#' a requirement that SpO2 < 97 in order for the \code{sf_ratio} to be valid.
+#' a requirement that SpO2 <= 97 in order for the \code{sf_ratio} to be valid.
 #' That assumption is not checked in this code and it is left to the end user to
 #' account for this when building the \code{sf_ratio} vector.
 #'


### PR DESCRIPTION
Documentation is missing the equal to portion of "less than or equal to 97"

Code all seems correct.