### PR TITLE
Add summary checklist and disable evaluation of block that is causing build error

### DIFF
--- a/vignettes/articles/ehr_implementation_notes.Rmd
+++ b/vignettes/articles/ehr_implementation_notes.Rmd
@@ -25,6 +25,36 @@ prepared as expected and returns scores accordingly.
 
 <hr>
 
+# Overview
+
+Here is a quick checklist to summarize how the Phoenix package should be integrated within an EHR. This is to aid understanding and verification; users still need to review all guidance from this full document.
+
+## Scoring Requirement
+
+* Phoenix score is only valid in the case of suspected infection
+
+## Exclusion Criteria
+
+* Patients still in their original birth hospitalization
+* Gestational age less than 37 weeks at encounter start
+* Age greater than or equal to 18 years (216 months) at encounter start
+
+## Data cleaning and preparation
+
+* Verify all variables in expected unit; convert as necessary. E.g. age in months; lactate in mmol/L, etc.
+* As appropriate replace invalid values with NULL; e.g. if age in months > 216 need to consider if should be scoring patient at all.
+* No imputation for NULL/invalid values
+* Last observation carry forward within appropriate window for each variable - max carry forward is from prior 24 hours.
+* Variables not present or not known should be passed in as NULL
+
+## Gotchas
+
+* Phoenix package doesn't calculate mean arterial pressure (MAP); Calculate MAP from SBP and DBP if not directly available; if both cuff and arterial values present, arterial MAP should be used.
+* Carefully review requirements of each input value. For example, only calculate SF ratio and pass into Phoenix package when SpO2 <= 97; only calculate and pass in PF ratio when FiO2 value is from the same time as or before the time of PaO2 lab.
+* Use last known good value to when calling Phoenix functions.
+
+<hr>
+
 # General Data Formatting Notes
 
 * `NULL` values are treated as non-score generating criteria. Do not populate null/unknown/not applicable values with estimates or outdated information.

--- a/vignettes/articles/python.Rmd
+++ b/vignettes/articles/python.Rmd
@@ -471,7 +471,9 @@ print(py_phoenix8_scores.info())
 print(py_phoenix8_scores.head())
 ```
 
-```{r, include = FALSE}
+```{r, include = FALSE, eval = FALSE}
+# this block currently doesn't evaluate due to error:
+# cannot coerce class 'c("pandas.DataFrame", "pandas.core.generic.NDFrame", "pandas.core.base.PandasObject", ' to a data.frame
 r_phoenix8_scores <-
   phoenix8(
     # respiratory

--- a/vignettes/articles/python.Rmd
+++ b/vignettes/articles/python.Rmd
@@ -404,7 +404,9 @@ print(py_phoenix_scores.info())
 print(py_phoenix_scores.head())
 ```
 
-```{r, include = FALSE}
+```{r, include = FALSE, eval = FALSE}
+# this block currently doesn't evaluate due to error:
+# cannot coerce class 'c("pandas.DataFrame", "pandas.core.generic.NDFrame", "pandas.core.base.PandasObject", ' to a data.frame
 r_phoenix_scores <-
   phoenix(
     # respiratory


### PR DESCRIPTION
Summary checklist as sent by email with a few additions. Changing evaluation to false for 2 code blocks that are not building in the python RMD file.