### PR TITLE
Fix 20

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phoenix
 Title: The Phoenix Pediatric Sepsis and Septic Shock Criteria
-Version: 1.1.3
+Version: 1.1.3.9000
 Authors@R:
     c(
       person(given = "Peter", family = "DeWitt",  email = "peter.dewitt@cuanschutz.edu", role = c("aut", "cre", "cov"), comment = c(ORCID = "0000-0002-6391-0795")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Version 1.1.3.9000
+
+## Bug Fixes
+
+* Use `get()` instead of `quote()` so that the methods will work when the
+  namespace is load and not attached. (#20)
+
 # Version 1.1.3:
 
 * Spelling and grammar fixes in the documentation for the R, python, and

--- a/R/phoenix.R
+++ b/R/phoenix.R
@@ -89,13 +89,13 @@ phoenix <- function(pf_ratio, sf_ratio, imv, other_respiratory_support,
   cl <- as.list(match.call())
   cl[["data"]] <- NULL
 
-  cl[[1]] <- quote(phoenix_respiratory)
+  cl[[1]] <- get("phoenix_respiratory", mode = "function")
   resp <- eval(as.call(cl), envir = data, enclos = parent.frame())
-  cl[[1]] <- quote(phoenix_cardiovascular)
+  cl[[1]] <- get("phoenix_cardiovascular", mode = "function")
   card <- eval(as.call(cl), envir = data, enclos = parent.frame())
-  cl[[1]] <- quote(phoenix_coagulation)
+  cl[[1]] <- get("phoenix_coagulation", mode = "function")
   coag <- eval(as.call(cl), envir = data, enclos = parent.frame())
-  cl[[1]] <- quote(phoenix_neurologic)
+  cl[[1]] <- get("phoenix_neurologic", mode = "function")
   neur <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
   rtn <-

--- a/R/phoenix8.R
+++ b/R/phoenix8.R
@@ -134,19 +134,19 @@ phoenix8 <- function(
   cl <- as.list(match.call())
   cl$data <- NULL
 
-  cl[[1]] <- quote(phoenix)
+  cl[[1]] <- get("phoenix", mode = "function")
   rtn <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
-  cl[[1]] <- quote(phoenix_endocrine)
+  cl[[1]] <- get("phoenix_endocrine", mode = "function")
   rtn$phoenix_endocrine_score <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
-  cl[[1]] <- quote(phoenix_immunologic)
+  cl[[1]] <- get("phoenix_immunologic", mode = "function")
   rtn$phoenix_immunologic_score <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
-  cl[[1]] <- quote(phoenix_renal)
+  cl[[1]] <- get("phoenix_renal", mode = "function")
   rtn$phoenix_renal_score <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
-  cl[[1]] <- quote(phoenix_hepatic)
+  cl[[1]] <- get("phoenix_hepatic", mode = "function")
   rtn$phoenix_hepatic_score <- eval(as.call(cl), envir = data, enclos = parent.frame())
 
   rtn$phoenix8_sepsis_score <-

--- a/tests/test-phoenix8.R
+++ b/tests/test-phoenix8.R
@@ -320,5 +320,53 @@ stopifnot(identical(p_a, p8_b[, 1:7]))
 stopifnot(identical(p_a, p8_c[, 1:7]))
 
 ################################################################################
+# verify namespace-loaded, package-detached usage
+phoenix_fun <- getExportedValue("phoenix", "phoenix")
+phoenix8_fun <- getExportedValue("phoenix", "phoenix8")
+
+detach("package:phoenix", unload = FALSE)
+
+p_ns <- phoenix_fun(pf_ratio = pfr,
+                    sf_ratio = sfr,
+                    imv = vent,
+                    other_respiratory_support = o2,
+                    vasoactives = vasos,
+                    lactate = lactate,
+                    map = map,
+                    platelets = plts,
+                    inr = inr,
+                    d_dimer = ddmr,
+                    fibrinogen = fib,
+                    gcs = gcs,
+                    fixed_pupils = pupils,
+                    age = age,
+                    data = DF)
+
+p8_ns <- phoenix8_fun(pf_ratio = pfr,
+                      sf_ratio = sfr,
+                      imv = vent,
+                      other_respiratory_support = o2,
+                      vasoactives = vasos,
+                      lactate = lactate,
+                      map = map,
+                      platelets = plts,
+                      inr = inr,
+                      d_dimer = ddmr,
+                      fibrinogen = fib,
+                      gcs = gcs,
+                      fixed_pupils = pupils,
+                      glucose = glc,
+                      anc = anc,
+                      alc = alc,
+                      creatinine = creatinine,
+                      bilirubin = bil,
+                      alt = alt,
+                      age = age,
+                      data = DF)
+
+stopifnot(identical(p_ns, p_a))
+stopifnot(identical(p8_ns, p8_a))
+
+################################################################################
 #                                 End of File                                  #
 ################################################################################


### PR DESCRIPTION
    Prior to this change construction of calls within phoenix8() and
    elsewhere used `quote()`.  This worked when the phoenix namespace as
    loaded and attached.  However, when the namespace was loaded and not
    attached then the symbol generated by quote() would not identify the
    needed function.
    
    This change uses get() instead of quote to retail the same
    functionallity when the namespace is loaded and not attached.